### PR TITLE
changed channel for Coach Professionl Development

### DIFF
--- a/channel_setup/delete_channels.sh
+++ b/channel_setup/delete_channels.sh
@@ -17,7 +17,8 @@
 # Bravo C - 5aee4435135b4039a3a824d96f72bfcb
 # Bravo D - 98ab8048107545da92e3394409955526
 # Grade 7 (Zambia) - 8d368058656544e2b7fe62eb2a632698
-# Coach Professional Development - 2c8cd5f3a4694adbb4be45025d9ca3dc
+# Coach Professional Development - 2c8cd5f3a4694adbb4be45025d9ca3dc - old 
+# Coach Professional Development - 19ea4c94ee484cb0b5bb617f5511f4c1
 
 delete_channels(){
 	
@@ -36,7 +37,7 @@ delete_channels(){
 		"5aee4435135b4039a3a824d96f72bfcb"
 		"98ab8048107545da92e3394409955526"
 		"8d368058656544e2b7fe62eb2a632698"
-		"2c8cd5f3a4694adbb4be45025d9ca3dc"
+		"19ea4c94ee484cb0b5bb617f5511f4c1"
 		)
 
 	# Inform the user that the deletion has begun
@@ -51,6 +52,7 @@ delete_channels(){
 	do
 		# For each channel, delete by channel_id
 		python -m kolibri manage deletechannel "$channel"
+		# python -m kolibri manage deletechannel "$channel"
 	done
 
 	echo "Done!"

--- a/channel_setup/import_channels.sh
+++ b/channel_setup/import_channels.sh
@@ -15,7 +15,9 @@
 # Bravo C - 5aee4435135b4039a3a824d96f72bfcb
 # Bravo D - 98ab8048107545da92e3394409955526
 # Grade 7 (Zambia) - 8d368058656544e2b7fe62eb2a632698
-# Coach Professional Development - 2c8cd5f3a4694adbb4be45025d9ca3dc
+# Coach Professional Development - 2c8cd5f3a4694adbb4be45025d9ca3dc - old 
+# Coach Professional Development - 19ea4c94ee484cb0b5bb617f5511f4c1
+
 
 # Default directory to look for Kolibri content
 DEFAULT_CONTENT_DIR=/opt/KOLIBRI_DATA/
@@ -39,7 +41,7 @@ import_channels_local(){
 		"5aee4435135b4039a3a824d96f72bfcb"
 		"98ab8048107545da92e3394409955526"
 		"8d368058656544e2b7fe62eb2a632698"
-		"2c8cd5f3a4694adbb4be45025d9ca3dc"
+		"19ea4c94ee484cb0b5bb617f5511f4c1"
 		)
 
 	# Inform the user that the importing has begun

--- a/channel_setup/import_channels_network.sh
+++ b/channel_setup/import_channels_network.sh
@@ -15,7 +15,8 @@
 # Bravo C - 5aee4435135b4039a3a824d96f72bfcb
 # Bravo D - 98ab8048107545da92e3394409955526
 # Grade 7 (Zambia) - 8d368058656544e2b7fe62eb2a632698
-# Coach Professional Development - 2c8cd5f3a4694adbb4be45025d9ca3dc
+# Coach Professional Development - 2c8cd5f3a4694adbb4be45025d9ca3dc - old 
+# Coach Professional Development - 19ea4c94ee484cb0b5bb617f5511f4c1
 
 
 
@@ -36,7 +37,7 @@ import_channels_network(){
 		"5aee4435135b4039a3a824d96f72bfcb"
 		"98ab8048107545da92e3394409955526"
 		"8d368058656544e2b7fe62eb2a632698"
-		"2c8cd5f3a4694adbb4be45025d9ca3dc"
+		"19ea4c94ee484cb0b5bb617f5511f4c1"
 		)
 
 	# Inform the user that the importing has begun

--- a/channel_setup/reorder_channels.sh
+++ b/channel_setup/reorder_channels.sh
@@ -30,7 +30,6 @@ python -m kolibri manage setchannelposition 98ab8048-1075-45da-92e3-394409955526
 
 python -m kolibri manage setchannelposition 8d368058-6565-44e2-b7fe-62eb2a632698 13 #Grade 7
 
-python -m kolibri manage setchannelposition 2c8cd5f3-a469-4adb-b4be-45025d9ca3dc 14 #Coach Professional Development
-
+python -m kolibri manage setchannelposition 19ea4c94 ee48-4cb0 b5bb-617f5511f4c1 14 #Coach Professional Development
 
 echo "Successfully reordered channels"


### PR DESCRIPTION
### Summary
Due to a bug after an update to Kolibri Studio by Learning Equality between January 13th-15th 2020, our old Coach Professional Development channel was unable to be updated and published. As a result, a clone of the channel and all of it's content was made to resolve the problem.
This PR replaces the old Channel ID for Coach Professional Development: **2c8cd5f3a4694adbb4be45025d9ca3dc** with the new Channel ID: **19ea4c94ee484cb0b5bb617f5511f4c1** in all of the Kolibri helper scripts.

### Reviewer guidance
Delete the old Coach Professional Development channel
`kolibri manage deletechannel 2c8cd5f3a4694adbb4be45025d9ca3dc`
Then import it from the internet using the import_channels_network.sh script. The new channel has the same content and now has a channel thumbnail image. All resources in this channel are only visible to Coaches by default
…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
