### PR TITLE
Optional flag to delete existing memberships. Check user_id exists before inserting learners

### DIFF
--- a/enroll_learners_into_class.py
+++ b/enroll_learners_into_class.py
@@ -30,6 +30,8 @@ argParser.add_argument(
 argParser.add_argument(
     "--delete",
     "-d",
+    action="store_true", 
+    default=False,
     help="Delete all existing memberships. The default value is False",
 )
 
@@ -145,39 +147,19 @@ if __name__ == "__main__":
     # Enroll learners into classes based on the supplied
     elif args.file and args.delete:
 
-        # convert provided option to lowercase
-        if args.delete.lower() == "true":
-            open_file = args.file
-            enroll_learners_into_class(open_file, delete_existing_memberships=True)
-        elif args.delete.lower() == "false":
-            open_file = args.file
-            enroll_learners_into_class(open_file)
-        else:
-            print(
-                'Error: value "{}" is incorrect for the optional arguement "Delete existing memberships". Type either True or False'.format(
-                    args.delete
-                )
-            )
-    elif args.file and args.delete and args.centre:
-        if args.delete.lower() == "true":
-            open_file = args.file
-            facility = args.centre
-            enroll_learners_into_class(
-                open_file, facility, delete_existing_memberships=True
-            )
-        elif args.delete.lower() == "false":
-            open_file = args.file
-            facility = args.centre
-            enroll_learners_into_class(open_file, facility)
-        else:
-            print(
-                'Error: value "{}" is incorrect for the optional arguement "Delete existing memberships". Type either True or False'.format(
-                    args.delete
-                )
-            )
+        # convert provided option to lowercase        
+        open_file = args.file
+        enroll_learners_into_class(open_file, delete_existing_memberships=True)
+        
+    elif args.file and args.delete and args.centre:        
+        open_file = args.file
+        facility = args.centre
+        enroll_learners_into_class(
+            open_file, facility, delete_existing_memberships=True
+        )
 
     # If neither the file nor the facility are passed in, stop the script in an error state
     else:
         sys.exit(
-            "No arguments passed in. Please pass in the path to the file and centre_id (optional)"
+            "No arguments passed in. Please pass in the path to the file, centre_id (optional) and delete_existing_memberships(optional)"
         )

--- a/enroll_learners_into_class.py
+++ b/enroll_learners_into_class.py
@@ -27,7 +27,11 @@ argParser.add_argument(
     "-c",
     help="Name of Facility( centre_id) in the case of multiple facilities on 1 device",
 )
-
+argParser.add_argument(
+    "--delete",
+    "-d",
+    help="Delete all existing memberships. The default value is False",
+)
 
 # Get the name of the default facility on the device
 # used as the default value in case facility is not passed in
@@ -35,7 +39,7 @@ def_facility = str(Facility.get_default_facility().name)
 
 
 def enroll_learners_into_class(
-    input_file, facilityname=def_facility, delete_existing_memberships=True
+    input_file, facilityname=def_facility, delete_existing_memberships=False
 ):
     """Function to enroll learners into classes using a csv file
     The file is expected to have columns user_id, centre, and grade. All other columns are ignored
@@ -126,7 +130,7 @@ if __name__ == "__main__":
     args = argParser.parse_args()
     # If the file is supplied and facility is not supplied
     # Enroll learners into classes based on the defualt facility
-    if args.file and not (args.centre):
+    if args.file and not (args.centre or args.delete):
         open_file = args.file
         enroll_learners_into_class(open_file)
 
@@ -136,6 +140,41 @@ if __name__ == "__main__":
         facility = args.centre
         open_file = args.file
         enroll_learners_into_class(open_file, facility)
+
+    # If the file and the delete existing membership are supplied
+    # Enroll learners into classes based on the supplied
+    elif args.file and args.delete:
+
+        # convert provided option to lowercase
+        if args.delete.lower() == "true":
+            open_file = args.file
+            enroll_learners_into_class(open_file, delete_existing_memberships=True)
+        elif args.delete.lower() == "false":
+            open_file = args.file
+            enroll_learners_into_class(open_file)
+        else:
+            print(
+                'Error: value "{}" is incorrect for the optional arguement "Delete existing memberships". Type either True or False'.format(
+                    args.delete
+                )
+            )
+    elif args.file and args.delete and args.centre:
+        if args.delete.lower() == "true":
+            open_file = args.file
+            facility = args.centre
+            enroll_learners_into_class(
+                open_file, facility, delete_existing_memberships=True
+            )
+        elif args.delete.lower() == "false":
+            open_file = args.file
+            facility = args.centre
+            enroll_learners_into_class(open_file, facility)
+        else:
+            print(
+                'Error: value "{}" is incorrect for the optional arguement "Delete existing memberships". Type either True or False'.format(
+                    args.delete
+                )
+            )
 
     # If neither the file nor the facility are passed in, stop the script in an error state
     else:

--- a/enroll_learners_into_class.py
+++ b/enroll_learners_into_class.py
@@ -30,7 +30,7 @@ argParser.add_argument(
 argParser.add_argument(
     "--delete",
     "-d",
-    action="store_true", 
+    action="store_true",
     default=False,
     help="Delete all existing memberships. The default value is False",
 )
@@ -132,30 +132,17 @@ if __name__ == "__main__":
     args = argParser.parse_args()
     # If the file is supplied and facility is not supplied
     # Enroll learners into classes based on the defualt facility
-    if args.file and not (args.centre or args.delete):
+    if args.file and not (args.centre):
         open_file = args.file
-        enroll_learners_into_class(open_file)
+        enroll_learners_into_class(open_file, delete_existing_memberships=args.delete)
 
     # If both the file and the facility are supplied
     # Enroll learners into classes based on the supplied
     elif args.file and args.centre:
-        facility = args.centre
-        open_file = args.file
-        enroll_learners_into_class(open_file, facility)
-
-    # If the file and the delete existing membership are supplied
-    # Enroll learners into classes based on the supplied
-    elif args.file and args.delete:
-
-        # convert provided option to lowercase        
-        open_file = args.file
-        enroll_learners_into_class(open_file, delete_existing_memberships=True)
-        
-    elif args.file and args.delete and args.centre:        
         open_file = args.file
         facility = args.centre
         enroll_learners_into_class(
-            open_file, facility, delete_existing_memberships=True
+            open_file, facility, delete_existing_memberships=args.delete
         )
 
     # If neither the file nor the facility are passed in, stop the script in an error state

--- a/insert_learners.py
+++ b/insert_learners.py
@@ -71,7 +71,19 @@ def insert_users(input_file, facility=def_facility):
             user_exists = FacilityUser.objects.filter(
                 username=user["username"], facility_id=facility_id
             ).exists()
-            if user_exists:
+            user_id_exists = FacilityUser.objects.filter(
+                id=user["user_id"], facility_id=facility_id
+            ).exists()
+            if user_id_exists:
+                # if a user with the same user_id already exists in the facility
+                # raise a value error and terminate the script
+                raise ValueError(
+                    "Duplicate user ID. There is already a user with ID {}".format(
+                        user["user_id"]
+                    )
+                )
+                sys.exit()
+            elif user_exists:
                 # if a user with the same username already exists in the facility
                 # raise a value error and terminate the script
                 raise ValueError(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Added optional flag on enroll learners script to indicate whether or not existing memberships should be deleted. 
Memberships are not deleted by default.

insert_learners script now checks if the user_id inserted already exists, and handles the error, rather than getting error raised by Kolibri if the user_id already exists.
…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mock-ups or specs for new features
 * links to the diffs for any dependency updates
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
