### PR TITLE
added flag for the soft delete option when deleting users

### DIFF
--- a/delete_learners.py
+++ b/delete_learners.py
@@ -17,8 +17,16 @@ argParser.add_argument(
     "--file", "-f", help="File containing user_ids of users to delete"
 )
 
+argParser.add_argument(
+    "--hard",
+    "-d",
+    action="store_true",
+    default=False,
+    help="Permanently delete users with user_ids in the file provided. The default value is False",
+)
 
-def delete_users(input_file):
+
+def delete_users(input_file,permanently_delete_user=False):
     """Function to delete users supplied in a csv file
     The csv file is expected to have a column user_id (uuid of each user to be deleted)
 
@@ -56,19 +64,36 @@ def delete_users(input_file):
             # get the full name of the user from the database
             user_to_delete = str(FacilityUser.objects.get(id=user["id"]).full_name)
 
-            # delete the user
-            # note: deleting in this way cascades to other models that reference the user
-            # i.e memberships, roles, loggers etc
-            FacilityUser.objects.get(id=user["id"]).delete()
+            user_obj = FacilityUser.objects.get(id=user["id"])
 
-            # print out a message containing the name of the user that was deleted
-            print_colored(
-                "User {} deleted".format(user_to_delete),
-                colors.fg.yellow,
-            )
+            #if the hard delete flag is supplied, permanently delete the user
+            if permanently_delete_user:
+                # delete the user
+                # note: deleting in this way cascades to other models that reference the user
+                # i.e memberships, roles, loggers etc
+                user_obj.delete()
 
-            # increment the counter by 1
-            num_deleted += 1
+                # print out a message containing the name of the user that was permanently deleted
+                print_colored(
+                    "User {} has been permanently deleted".format(user_to_delete),
+                    colors.fg.yellow,
+                )
+
+                # increment the counter by 1
+                num_deleted += 1
+            else:
+                #soft delete
+                user_obj.set_deleted = True #set deleted to true
+                user_obj.save()
+
+                # print out a message containing the name of the user that was soft deleted
+                print_colored(
+                    "User {} has been soft deleted".format(user_to_delete),
+                    colors.fg.yellow,
+                )
+
+                # increment the counter by 1
+                num_deleted += 1
 
         # once the loop completes, print out the number of users that were deleted
         if len(to_delete) == num_deleted:
@@ -90,6 +115,6 @@ if __name__ == "__main__":
     args = argParser.parse_args()
     if args.file:
         open_file = args.file
-        delete_users(open_file)
+        delete_users(open_file,permanently_delete_user=args.hard)
     else:
         sys.exit("Please supply a file containing the users to delete")


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This is a modification of the delete_learners.py script to include the option for soft delete. By default, users are soft deleted. When the flag -d is provided, the users are permanently deleted.
…

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
